### PR TITLE
Add generic type parameter for value of a route

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -1,12 +1,37 @@
 type Parsed = [RegExp, string[]]
 
+/**
+ * Routes<T> is the base type for route definitions. It maps a pattern string
+ * to a value of type `T`. This value will be returned inside the `Result<T>`.
+ * 
+ * Type parameter `T` holds the type of the result, e.g. `string`.
+ */
 export type Routes<T> = { [pattern: string]: T }
 
+/**
+ * Result is the return type for matched route definitions. It augments the
+ * value of type `T` from the `Routes<T>` (in the `page` field) by additional
+ * route parameters, which have been stored in `params`.
+ * 
+ * If no matching pattern can be found for a URL, the result is `null`.
+ */
 export type Result<T> = {
+    /**
+     * page holds the value defined in the original mapping (see `Routes<T>`).
+     */
     page: T
+    /**
+     * params holds a key value mapping of URL parameters, if the pattern
+     * used any.
+     */
     params: { [key: string]: any }
 } | null
 
+/**
+ * Matcher defines the type of the routing function. A routing function will
+ * take one string as input, the `url` and try to match it to the routes that
+ * it has been created with. If no match has been found, it returns `null`.
+ */
 export type Matcher<T> = (url: string) => Result<T>
 
 // Parses a URL pattern such as `/users/:id`
@@ -40,6 +65,10 @@ const parse = (pattern: string): Parsed => {
     return [new RegExp('^' + pattern + '(?:\\?([\\s\\S]*))?$'), names]
 }
 
+/**
+ * This factory that will create and return a routing function
+ * (see `Matcher<T>`) from the routing configuration in `routes`.
+ */
 export default <T>(routes: Routes<T>): Matcher<T> => {
     // loop through each route we're
     // and build the shell of our

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,13 +1,13 @@
 type Parsed = [RegExp, string[]]
 
-export type Routes = { [pattern: string]: any }
+export type Routes<T> = { [pattern: string]: T }
 
-export type Result = {
-    page: any
+export type Result<T> = {
+    page: T
     params: { [key: string]: any }
 } | null
 
-export type Matcher = (url: string) => Result
+export type Matcher<T> = (url: string) => Result<T>
 
 // Parses a URL pattern such as `/users/:id`
 // and builds and returns a regex that can be used to
@@ -40,7 +40,7 @@ const parse = (pattern: string): Parsed => {
     return [new RegExp('^' + pattern + '(?:\\?([\\s\\S]*))?$'), names]
 }
 
-export default (routes: Routes): Matcher => {
+export default <T>(routes: Routes<T>): Matcher<T> => {
     // loop through each route we're
     // and build the shell of our
     // route cache.
@@ -50,7 +50,7 @@ export default (routes: Routes): Matcher => {
 
     // main result is a function that can be called
     // with the url
-    return (url: string): Result => {
+    return (url: string): Result<T> => {
         for (let i = 0; i < patterns.length; i++) {
             const pattern = patterns[i]
 


### PR DESCRIPTION
I added a type parameter for the value of the routing configuration. This gets rid of a few `any`s and makes strong typing enthusiasts (like me) happy ;-)

Also I added doc comments to the exports to increase guidance in IDEs that support them.